### PR TITLE
Turn off auto-downscaling during inactive periods

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@ primary_region = 'ewr'
   internal_port = 8080
   force_https = true
   auto_stop_machines = true
-  auto_start_machines = true
+  auto_start_machines = false
   min_machines_running = 0
   processes = ['app']
 


### PR DESCRIPTION
## Summary
- Machines take only .5s to restart after inactive periods, but still want the site to load as fast as possible
<img width="326" alt="image" src="https://github.com/akan72/xyz/assets/29241719/4b8b205f-fb74-4f90-9bfc-3b8037871702">

- https://community.fly.io/t/what-does-downscaling-app-mean/12309