### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,14 @@ jobs:
     name: Rust (fmt + check)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - run: cargo fmt --all --check
 
@@ -50,19 +50,19 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install worker-build
         run: cargo install worker-build --locked
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request' && steps.preview.outputs.preview_url
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
           PREVIEW_NAME: ${{ steps.preview.outputs.preview_name }}

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -23,10 +23,10 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Update PR comment
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PREVIEW_NAME: ${{ steps.delete.outputs.preview_name }}
           DELETED: ${{ steps.delete.outputs.deleted }}


### PR DESCRIPTION
## Summary
Pin every GitHub Action to an immutable commit SHA instead of a mutable tag/branch, with the version (or ref) preserved in a trailing comment. Tags like `@v4` and branches like `@stable` can be re-pointed upstream, so this prevents the action versions from changing underneath us between runs.

Frozen at what each ref currently resolves to:

| Action | Pinned SHA | Comment |
|---|---|---|
| `actions/checkout` | `34e1148` | `# v4.3.1` |
| `actions/setup-node` | `49933ea` | `# v4.4.0` |
| `actions/github-script` | `f28e40c` | `# v7.1.0` |
| `Swatinem/rust-cache` | `e18b497` | `# v2` |
| `dtolnay/rust-toolchain` | `29eef33` | `# stable` |

Notes:
- `dtolnay/rust-toolchain@stable` is a rolling **branch**, not a release tag — pinning the SHA freezes the current stable toolchain action; comment kept as `# stable`.
- `Swatinem/rust-cache` keeps its `v2` major tag on a standalone commit with no co-located patch tag, so the comment stays `# v2`.
